### PR TITLE
I fixed mage damage.

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -974,7 +974,7 @@ namespace ACE.Server.WorldObjects
                                     var rng = new Random().NextDouble();
                                     var procRate = amulet.LeyLineTriggerChance;
                                     if (isPvP && spell.IsHarmful)                                
-                                        procRate = .03; //proc spells are super op.
+                                        procRate = 0.01; //proc spells are super op.
                                     if (procRate > rng)
                                     {
                                         amulet.NextLeyLineTriggerTime = currentTime + LeyLineAmulet.LeyLineTriggerInterval;


### PR DESCRIPTION
If you're playing a character with maxed war skill and are using an average CS BZ wand, you will kill a maxed 100 base endurance character 32% of the time with 2 bolts and a streak. You will fail to kill a maxed 10 base endurance character 32% of the time. 

I've also scaled the damage down at lower skill levels so that mages casting 7s don't come out of the gate two hitting people.